### PR TITLE
PROM-105: Fix PostCSS and Tailwind CSS build configuration issue

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  plugins: [],
+  plugins: {
+    "@tailwindcss/postcss": {},
+    autoprefixer: {},
+  },
 };


### PR DESCRIPTION
Fix: Corrected PostCSS configuration to resolve build failure

The `postcss.config.js` file has been updated to correctly include `@tailwindcss/postcss` and `autoprefixer` plugins. This resolves the previous build errors related to the PostCSS and Tailwind CSS setup, enabling the Next.js development server to start successfully with `npm run dev`.

The application is now accessible in the browser after the server starts. Unrelated build errors might be present when running `npm run build`, but the core blocker identified in this task has been resolved.