### PR TITLE
PROM-69: Projects Page - Implement User's Project Listing

### DIFF
--- a/src/app/(main)/components/ProjectCard.tsx
+++ b/src/app/(main)/components/ProjectCard.tsx
@@ -14,15 +14,15 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
     router.push(`/projects/${project.id}`);
   };
 
-  const isHoverable = project.status !== 'error'; // Not clickable if error status
+  const isHoverable = project.status !== 'failed'; // Not clickable if error status
 
   return (
     <div
       className={`bg-white shadow-md rounded-lg p-6 mb-4 cursor-pointer transition-all duration-200
         ${isHoverable ? 'hover:shadow-lg hover:border-blue-500 border border-transparent' : ''}
-        ${project.status === 'error' ? 'opacity-70 border-red-500 border' : ''}
+        ${project.status === 'failed' ? 'opacity-70 border-red-500 border' : ''}
       `}
-      style={project.status === 'error' ? { pointerEvents: 'none' } : {}} // Disable clicks for error projects
+      style={project.status === 'failed' ? { pointerEvents: 'none' } : {}} // Disable clicks for error projects
       onClick={isHoverable ? handleClick : undefined}
     >
       <h3 className="text-xl font-semibold text-gray-800 mb-2">{project.name}</h3>
@@ -41,7 +41,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
         )}
       </div>
 
-      {project.status === 'error' && (
+      {project.status === 'failed' && (
         <p className="text-red-500 text-sm mt-2">Error: Project failed</p>
       )}
     </div>


### PR DESCRIPTION
Fix: Correctly handle 'failed' project status in ProjectCard
This commit updates the `ProjectCard` component to correctly recognize and display projects with a `failed` status. Previously, the component incorrectly checked for an 'error' status, which is not defined in the `ProjectSummary` type. This change ensures that projects marked as 'failed' are visually distinct (opacity, red border) and non-clickable, aligning with the intended UI behavior and the existing type definitions.